### PR TITLE
Add image tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4108,9 +4108,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001242",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz",
-      "integrity": "sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==",
+      "version": "1.0.30001251",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
+      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -61,7 +61,7 @@ export default {
       //.style("visibility", "hidden")
       .attr("class", "tooltip")
       .style("opacity", 0)
-      .style("background-color", "blue")
+      .style("background-color", "royalblue")
       .style("border", "solid")
       .style("border-width", "1px")
       .style("border-radius", "5px")
@@ -160,7 +160,10 @@ export default {
             .on("mouseover", function(d) {		
                 self.tooltip.transition()		
                     .style("opacity", .9)		
+              // TODO: change image to match feature
+              // can use image_file variable added to this.volume as ending to https://labs.waterdata.usgs.gov/visualizations/images/
                 self.tooltip
+                .html("<img src='http://upload.wikimedia.org/wikipedia/commons/b/b3/Mali_Tombouctou.png'>")
                     .style("left", (self.d3.event.pageX) + "px")		
                     .style("top", (self.d3.event.pageY) + "px");	
                 })					

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -155,26 +155,8 @@ export default {
             .attr("width", 10)
             .attr("height", y_height)
             .attr("fill", "royalblue")
-
-            var file = 'salineLake.jpg';
-
-          svg_add
-            .selectAll(".bar")
             .on("mouseover", function(d) {		
-                self.tooltip.transition()		
-                    .style("opacity", .9)		
-                 var img_file = self.imagePath(d.image_file)
-              // uses image_file from this.volume as ending to https://labs.waterdata.usgs.gov/visualizations/images/
-                self.tooltip
-                .html("<img src='" + img_file + "' >")
-                    .attr("pupUp", "class")
-                    .style("width", "220px")
-                    .style("height", "220px")
-                    .style("left", (self.d3.event.pageX) + "px")		
-                    .style("top", (self.d3.event.pageY) + "px");	
-                  self.tooltip.select('img')
-                  .style("width", "200px")
-                    .style("height", "200px")
+                self.populateTooltip(d)
                 })					
             .on("mouseout", function(d) {		
                 self.tooltip.transition()		
@@ -186,6 +168,29 @@ export default {
         imagePath(file){
           const image_src = 'https://labs.waterdata.usgs.gov/visualizations/images/' + file
           return image_src
+
+        },
+        populateTooltip(d){
+          const self = this;
+
+          self.tooltip
+            .transition()		
+            .style("opacity", .9)		
+
+          // use image_file from this.volume as ending to https://labs.waterdata.usgs.gov/visualizations/images/
+         var img_file = self.imagePath(d.image_file)
+        
+          self.tooltip
+          .html("<img src='" + img_file + "' >")
+              .attr("pupUp", "class")
+              .style("width", "220px")
+              .style("height", "220px")
+              .style("left", (self.d3.event.pageX) + "px")		
+              .style("top", (self.d3.event.pageY) + "px");	
+
+          self.tooltip.select('img')
+            .style("width", "200px")
+              .style("height", "200px")
 
         }
 

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -155,14 +155,8 @@ export default {
             .attr("width", 10)
             .attr("height", y_height)
             .attr("fill", "royalblue")
-            .on("mouseover", function(d) {		
-                self.populateTooltip(d)
-                })					
-            .on("mouseout", function(d) {		
-                self.tooltip.transition()		
-                    .duration(500)		
-                    .style("opacity", 0);	
-        });
+            .on("mouseover", d => self.populateTooltip(d))					
+            .on("mouseout", d => self.fadeEl(self.tooltip, 0, 50))
 
         },
         imagePath(file){
@@ -173,15 +167,13 @@ export default {
         populateTooltip(d){
           const self = this;
 
-          self.tooltip
-            .transition()		
-            .style("opacity", .9)		
+          self.fadeEl(self.tooltip, 0.9)
 
           // use image_file from this.volume as ending to https://labs.waterdata.usgs.gov/visualizations/images/
-         var img_file = self.imagePath(d.image_file)
+          var img_file = self.imagePath(d.image_file)
         
           self.tooltip
-          .html("<img src='" + img_file + "' >")
+            .html("<img src='" + img_file + "' >")
               .attr("pupUp", "class")
               .style("width", "220px")
               .style("height", "220px")
@@ -190,7 +182,11 @@ export default {
 
           self.tooltip.select('img')
             .style("width", "200px")
-              .style("height", "200px")
+            .style("height", "200px")
+
+        },
+        fadeEl(el, alpha, time_duration = 0){
+          el.transition().duration(time_duration).style("opacity", alpha)
 
         }
 

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -36,12 +36,7 @@ export default {
       margin: { top: 50, right: 50, bottom: 50, left: 50 },
       svg_chart: null,
       logpile_container: null,
-      scales: {
-        linear: d3.scaleLinear(),
-        log10:  d3.scaleLog().base(10)
-    },
-
-    }
+      }
   },
   mounted(){      
       this.d3 = Object.assign(d3Base);
@@ -124,7 +119,7 @@ export default {
             .attr("transform", "translate(" + 0 + ", " + y_pos + ")")
             .attr("class", "x-axis")
             .call(xAxis)
-            .call(g => g.select(".domain")
+            .call(g => g.select(".domain") // style axis and ticks
                 .attr("stroke-opacity", 0.5))
             .call(g => g.selectAll(".tick line")
                 .attr("stroke-opacity", 0.5))
@@ -147,8 +142,7 @@ export default {
             .attr("y", y_height)
             .attr("width", 2)
             .attr("height", y_height)
-            .attr("opacity", 0.85)
-            .attr("fill", "pink")    // TODO: color based on type
+            .attr("fill", "royalblue")
 
         }
 
@@ -162,5 +156,4 @@ export default {
   width: 90vw;
   margin: 5vw;
 }
-
 </style>

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -76,7 +76,7 @@ export default {
 
             // read in data
             let promises = [
-                self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/water_volume_logpile.csv", this.d3.autoType),
+                self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/abbott_pools_and_fluxes_images.csv", this.d3.autoType),
             ];
             Promise.all(promises).then(self.callback);
         },
@@ -89,6 +89,7 @@ export default {
           // 'row_' variables provide the numeric bounds for each row in logpile
           // Vol_row and Vol_prefix are for positioning (y-axis) and labelling volumes
           this.volume = data[0];
+          console.log(this.volume)
 
           // draw chart
           this.addlogpile(this.volume)
@@ -151,27 +152,40 @@ export default {
             .attr("class", d => { return "bar " + d.Type }) // to grab in interaction
             .attr("x", d => xScale(x(d)))
             .attr("y", y_height)
-            .attr("width", 2)
+            .attr("width", 10)
             .attr("height", y_height)
             .attr("fill", "royalblue")
+
+            var file = 'salineLake.jpg';
 
           svg_add
             .selectAll(".bar")
             .on("mouseover", function(d) {		
                 self.tooltip.transition()		
                     .style("opacity", .9)		
-              // TODO: change image to match feature
-              // can use image_file variable added to this.volume as ending to https://labs.waterdata.usgs.gov/visualizations/images/
+                 var img_file = self.imagePath(d.image_file)
+              // uses image_file from this.volume as ending to https://labs.waterdata.usgs.gov/visualizations/images/
                 self.tooltip
-                .html("<img src='http://upload.wikimedia.org/wikipedia/commons/b/b3/Mali_Tombouctou.png'>")
+                .html("<img src='" + img_file + "' >")
+                    .attr("pupUp", "class")
+                    .style("width", "220px")
+                    .style("height", "220px")
                     .style("left", (self.d3.event.pageX) + "px")		
                     .style("top", (self.d3.event.pageY) + "px");	
+                  self.tooltip.select('img')
+                  .style("width", "200px")
+                    .style("height", "200px")
                 })					
             .on("mouseout", function(d) {		
                 self.tooltip.transition()		
                     .duration(500)		
                     .style("opacity", 0);	
         });
+
+        },
+        imagePath(file){
+          const image_src = 'https://labs.waterdata.usgs.gov/visualizations/images/' + file
+          return image_src
 
         }
 
@@ -187,13 +201,16 @@ export default {
 }
 .tooltip {	
     text-align: center;			
-    width: 60px;					
+    width: 60px;				
+    max-width: 100px;	
     height: 28px;					
     padding: 2px;				
-    font: 12px sans-serif;		
-    background: lightsteelblue;	
-    border: 0px;		
     border-radius: 8px;			
     z-index: 100;	
+
+    img {
+      max-width: 100px;
+      max-height:100px;
+    }
 }
 </style>

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -77,7 +77,6 @@ export default {
             // read in data
             let promises = [
                 self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/water_volume_logpile.csv", this.d3.autoType),
-                self.d3.csv(self.publicPath + 'water_volume_logpile.csv', this.d3.autotype)
             ];
             Promise.all(promises).then(self.callback);
         },
@@ -90,7 +89,6 @@ export default {
           // 'row_' variables provide the numeric bounds for each row in logpile
           // Vol_row and Vol_prefix are for positioning (y-axis) and labelling volumes
           this.volume = data[0];
-          this.image_paths = data[1];
 
           // draw chart
           this.addlogpile(this.volume)

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -36,6 +36,7 @@ export default {
       margin: { top: 50, right: 50, bottom: 50, left: 50 },
       svg_chart: null,
       logpile_container: null,
+      tooltip: null,
       }
   },
   mounted(){      
@@ -47,11 +48,18 @@ export default {
     this.h = document.getElementById("logpile-container").offsetHeight;
     
     // create svg that will hold chart
-    this.svg_logpile = this.d3.select("#logpile-container")
+    this.svg_logpile = this.logpile_container
       .append("svg")
       .classed("logpile-chart", true)
       .attr("viewBox", "0 0 " + this.w + " " + this.h)
       .attr("preserveAspectRatio", "xMidYMid meet")
+
+    // define div for tooltip
+    this.tooltip = this.logpile_container
+      .append("div")
+      .attr("class", "tooltip")
+      .style("opacity", 0)
+      .attr("fill", "royalblue")
 
     this.loadData();
 
@@ -66,6 +74,7 @@ export default {
             // read in data
             let promises = [
                 self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/water_volume_logpile.csv", this.d3.autoType),
+                self.d3.csv(self.publicPath + 'water_volume_logpile.csv', this.d3.autotype)
             ];
             Promise.all(promises).then(self.callback);
         },
@@ -78,8 +87,11 @@ export default {
           // 'row_' variables provide the numeric bounds for each row in logpile
           // Vol_row and Vol_prefix are for positioning (y-axis) and labelling volumes
           this.volume = data[0];
+          this.image_paths = data[1];
+          console.log(this.image_paths)
 
           this.addlogpile(this.volume)
+
         },
         addlogpile(data){
           // TODO: draw logpile 
@@ -106,6 +118,7 @@ export default {
         } = {}) {
 
           const x_margin = 20;
+          const self = this;
 
           // x axis scale
           var xScale = type()
@@ -134,7 +147,7 @@ export default {
           svg_add
             .selectAll(".bar")
             .data(data, function(d) { return d.Type })
-            .enter()
+          .enter()
             .append("rect")
             .classed("bar", true)
             .attr("class", d => { return "bar " + d.Type }) // to grab in interaction
@@ -143,6 +156,19 @@ export default {
             .attr("width", 2)
             .attr("height", y_height)
             .attr("fill", "royalblue")
+            .on("mouseover", function(d) {		
+                self.tooltip.transition()		
+                    .duration(100)
+                    .style("opacity", .9)			
+                self.tooltip
+                    .style("left", (self.d3.event.pageX) + "px")		
+                    .style("top", (self.d3.event.pageY - 28) + "px");	
+                })					
+            .on("mouseout", function(d) {		
+                self.tooltip.transition()		
+                    .duration(500)		
+                    .style("opacity", 0);	
+        });
 
         }
 
@@ -155,5 +181,17 @@ export default {
   height: 50vh;
   width: 90vw;
   margin: 5vw;
+}
+.tooltip {	
+    position: absolute;			
+    text-align: center;			
+    width: 60px;					
+    height: 28px;					
+    padding: 2px;				
+    font: 12px sans-serif;		
+    background: lightsteelblue;	
+    border: 0px;		
+    border-radius: 8px;			
+    pointer-events: none;			
 }
 </style>

--- a/src/components/logpile.vue
+++ b/src/components/logpile.vue
@@ -57,15 +57,18 @@ export default {
     // define div for tooltip
     this.tooltip = this.logpile_container
       .append("div")
+      .style("position", "absolute")
+      //.style("visibility", "hidden")
       .attr("class", "tooltip")
       .style("opacity", 0)
-      .attr("fill", "royalblue")
+      .style("background-color", "blue")
+      .style("border", "solid")
+      .style("border-width", "1px")
+      .style("border-radius", "5px")
+      .style("padding", "10px")
+
 
     this.loadData();
-
-    // resize chart when window changes 
-    //window.addEventListener("resize", this.drawChart)
-
     },
     methods:{
         loadData(){
@@ -88,8 +91,8 @@ export default {
           // Vol_row and Vol_prefix are for positioning (y-axis) and labelling volumes
           this.volume = data[0];
           this.image_paths = data[1];
-          console.log(this.image_paths)
 
+          // draw chart
           this.addlogpile(this.volume)
 
         },
@@ -103,9 +106,6 @@ export default {
             x_min: 1, // necessary for log
             var_class: 'pool'
           })
-        },
-        resize(){
-            // TODO: make chart responsive
         },
         drawChart(data, {
           value = d => d, // convenience alias for x
@@ -156,13 +156,15 @@ export default {
             .attr("width", 2)
             .attr("height", y_height)
             .attr("fill", "royalblue")
+
+          svg_add
+            .selectAll(".bar")
             .on("mouseover", function(d) {		
                 self.tooltip.transition()		
-                    .duration(100)
-                    .style("opacity", .9)			
+                    .style("opacity", .9)		
                 self.tooltip
                     .style("left", (self.d3.event.pageX) + "px")		
-                    .style("top", (self.d3.event.pageY - 28) + "px");	
+                    .style("top", (self.d3.event.pageY) + "px");	
                 })					
             .on("mouseout", function(d) {		
                 self.tooltip.transition()		
@@ -183,7 +185,6 @@ export default {
   margin: 5vw;
 }
 .tooltip {	
-    position: absolute;			
     text-align: center;			
     width: 60px;					
     height: 28px;					
@@ -192,6 +193,6 @@ export default {
     background: lightsteelblue;	
     border: 0px;		
     border-radius: 8px;			
-    pointer-events: none;			
+    z-index: 100;	
 }
 </style>


### PR DESCRIPTION
This sets up a tooltip for each water feature on the chart. The tooltip is populated with an image that is stored in s3 via the targets pipeline (https://github.com/USGS-VIZLAB/pools-and-fluxes/pull/3). This sets basic function only. Bekah is gathering images, not all features have images yet.
