### PR TITLE
Refine page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2389,9 +2389,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2581,14 +2581,11 @@
           }
         },
         "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+          "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
+          "optional": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -2705,9 +2702,9 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader@16.3.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.3.0.tgz",
-          "integrity": "sha512-UDgni/tUVSdwHuQo+vuBmEgamWx88SuSlEb5fgdvHrlJSPB9qMBRF6W7bfPWSqDns425Gt1wxAUif+f+h/rWjg==",
+          "version": "npm:vue-loader@16.8.3",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2717,9 +2714,9 @@
           },
           "dependencies": {
             "loader-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+              "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
               "dev": true,
               "optional": true,
               "requires": {

--- a/public/data/pools-fluxes-examples-limited.csv
+++ b/public/data/pools-fluxes-examples-limited.csv
@@ -1,0 +1,38 @@
+﻿type,feature,value_km_3
+Pool,Rivers,1900
+Pool,Snowpack,2900
+Pool,Atmospheric moisture - over land,3000
+Pool,Atmospheric moisture - over ocean,10000
+Pool,Reservoirs,10800
+Pool,Wetlands,14100
+Pool,Soil moisture,54100
+Pool,Lakes - saline,94700
+Pool,Lakes - fresh,108000
+Pool,Permafrost,207000
+Pool,Groundwater,22630000
+Pool,Ice sheets and glaciers,25800000
+Pool,Ocean - mixed zone,134000000
+Pool,Ocean - deep water zone,1206000000
+Flux,Streamflow to closed basins,800
+Flux,snowmelt,3100
+Flux,Groundwater discharge to ocean,4500
+Flux,Groundwater recharge,13000
+Flux,human water use,24400
+Flux,Streamflow to ocean,36000
+Flux,Transport of moisture from ocean to land,46000
+Flux,Evapotranspiration,68900
+Flux,Precipitation over land ,111000
+Flux,Precipitation over ocean,380500
+Flux,Ocean evaporation,420500
+Flux,Ocean circulation,7100000
+Example,Great Salt Lake,18.9
+Example,Dead Sea,147
+Example,Lake Winnepeg,284
+Example,Lake Erie,480
+Example,Lake Titicaca,893
+Example,Lake Victoria,2700
+Example,Grand canyon,4166.8
+Example,Lake Vostok,5400
+Example,Lake Superior,11600
+Example,Lake Baikal,23600
+Example,Caspian Sea,78200

--- a/src/components/HeaderUSGS.vue
+++ b/src/components/HeaderUSGS.vue
@@ -14,7 +14,7 @@
         >
           <img
             class="img"
-            src="@/assets/usgsHeaderAndFooter/images/usgsvizlab-logo-wordmark-black.png"
+            src="@/assets/usgsHeaderAndFooter/images/usgsLogo_white-01.png"
             alt="Home"
           >
         </a>
@@ -38,7 +38,7 @@
     margin-left: auto;
     padding-left: 15px;
     padding-right: 15px;
-    border-bottom: 2px solid black;
+    border-bottom: 2px solid white;
   }
   .tmp-container a {
     text-decoration: none;
@@ -54,7 +54,7 @@
   }
   /* header (only) nav */
   .header-nav {
-    background: white;
+    background: black;
 ;
   }
   .logo-header img {

--- a/src/components/pool_flux_chart.vue
+++ b/src/components/pool_flux_chart.vue
@@ -17,7 +17,7 @@ export default {
       // dimensions
       w: null,
       h: null,
-      margin: { top: 10, right: 10, bottom: 20, left: 200 },
+      margin: { top: 10, right: 25, bottom: 20, left: 200 },
       chart_width: null,
       chart_height: null,
       svg_chart: null,
@@ -35,12 +35,10 @@ export default {
     this.chart_height = this.h - this.margin.top - this.margin.bottom;
     this.chart_container = this.d3.select("#chart-container")
     
-    
     // define div for tooltip
     // this.tooltip = this.chart_container
     //   .append("div")
     //   .attr("class", "tooltip")
-
 
     // create svg that will hold chart
     this.svg_chart = this.chart_container
@@ -59,8 +57,7 @@ export default {
 
             // read in data
             let promises = [
-                self.d3.csv(self.publicPath + "data/pools-fluxes-examples-limited.csv", this.d3.autoType), //self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/abbott_pools_and_fluxes_images.csv", this.d3.autoType)
-                self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/abbott_pools_and_fluxes_images.csv", this.d3.autoType)
+                self.d3.csv(self.publicPath + "data/pools-fluxes-examples-limited.csv", this.d3.autoType) //self.d3.csv("https://labs.waterdata.usgs.gov/visualizations/data/abbott_pools_and_fluxes_images.csv", this.d3.autoType)
             ];
             Promise.all(promises).then(self.callback);
         },
@@ -68,10 +65,6 @@ export default {
           const self = this;
 
           // pools and fluxes of water
-          // long-form data with columns Type, Category, Feature_group, Feature, 
-          // Vol_1000km3,Vol_km3, Vol_m3, Vol_km3_log10, Vol_row, Vol_prefix, row_start, row_end
-          // 'row_' variables provide the numeric bounds for each row in logpile
-          // Vol_row and Vol_prefix are for positioning (y-axis) and labelling volumes
           this.volume = data[0];
           console.log(this.volume)
 
@@ -98,7 +91,6 @@ export default {
           let_class
         } = {}) {
 
-          // const x_margin = 20;
           const self = this;
 
           // x axis scale
@@ -110,14 +102,11 @@ export default {
             .attr("transform", "translate(0," + this.chart_height + ")")
             .call(this.d3.axisBottom(xScale))
 
-          // let xAxis = this.d3.axisBottom(xScale)
-
+          // y axis scale for lolipop chart
           const yScale = this.d3.scaleBand()
             .range([0, this.chart_height])
             .domain(data.map(function(d) { return d.feature }))
             .padding(1);
-
-          console.log(yScale.domain)
 
           this.svg_chart.append("g")
             .call(this.d3.axisLeft(yScale))
@@ -132,6 +121,8 @@ export default {
               .attr("y1", function(d) { return yScale(d.feature); })
               .attr("y2", function(d) { return yScale(d.feature); })
               .style("stroke", "grey")
+              // .on("mouseover", d => self.populateTooltip(d))					
+              // .on("mouseout", d => self.fadeEl(self.tooltip, 0, 50))
 
           // Add lolipop circles
           this.svg_chart.selectAll("chartCircles")
@@ -155,39 +146,8 @@ export default {
                 }
               })
               .attr("stroke", "white")
-
-          // add pools and fluxes
-          // this.svg_chart.append("g")
-          //   .attr("transform", "translate(" + 0 + ", " + y_pos + ")")
-          //   .attr("class", "x-axis")
-          //   .call(xAxis)
-          //   .call(g => g.select(".domain") // style axis and ticks
-          //       .attr("stroke-opacity", 0.5))
-          //   .call(g => g.selectAll(".tick line")
-          //       .attr("stroke-opacity", 0.5))
-
-          // // draw data elements
-          // let svg_add = this.svg_chart
-          //   .append("g")
-          //   .classed(let_class, true)
-
-          // // TODO: change shape and appearance of volumes on chart
-          // // currently barcode
-          // svg_add
-          //   .selectAll(".bar")
-          //   .data(data, function(d) { return d.feature })
-          // .enter()
-          //   .append("rect")
-          //   .classed("bar", true)
-          //   .attr("class", d => { return "bar " + d.feature }) // to grab in interaction
-          //   .attr("x", d => xScale(x(d)))
-          //   .attr("y", this.chart_height-y_height)
-          //   .attr("width", 5)
-          //   .attr("height", y_height)
-          //   .attr("fill", "royalblue")
-          //   .attr("stroke", "white")
-          //   // .on("mouseover", d => self.populateTooltip(d))					
-          //   // .on("mouseout", d => self.fadeEl(self.tooltip, 0, 50))
+              // .on("mouseover", d => self.populateTooltip(d))					
+              // .on("mouseout", d => self.fadeEl(self.tooltip, 0, 50))
 
         },
         imagePath(file){
@@ -206,10 +166,6 @@ export default {
           self.tooltip
             .html("<img src='" + img_file + "' >")
               .attr("class", "popUp")
-              // .style("width", "220px")
-              // .style("height", "220px")
-              // .style("left", (self.d3.event.pageX) + "px")		
-              // .style("top", (self.d3.event.pageY) + "px");	
 
           self.tooltip.select('img')
             .style("width", "200px")

--- a/src/components/pool_flux_chart.vue
+++ b/src/components/pool_flux_chart.vue
@@ -18,10 +18,10 @@ export default {
       w: null,
       h: null,
       margin: { top: 10, right: 25, bottom: 20, left: 200 },
-      chart_width: null,
-      chart_height: null,
-      svg_chart: null,
-      chart_container: null,
+      chartWidth: null,
+      chartHeight: null,
+      svgChart: null,
+      chartContainer: null,
       tooltip: null,
       }
   },
@@ -31,20 +31,20 @@ export default {
     // chart elements
     this.w = document.getElementById("chart-container").offsetWidth;
     this.h = document.getElementById("chart-container").offsetHeight;
-    this.chart_width = this.w - this.margin.left - this.margin.right;
-    this.chart_height = this.h - this.margin.top - this.margin.bottom;
-    this.chart_container = this.d3.select("#chart-container")
+    this.chartWidth = this.w - this.margin.left - this.margin.right;
+    this.chartHeight = this.h - this.margin.top - this.margin.bottom;
+    this.chartContainer = this.d3.select("#chart-container")
     
     // define div for tooltip
-    // this.tooltip = this.chart_container
+    // this.tooltip = this.chartContainer
     //   .append("div")
     //   .attr("class", "tooltip")
 
     // create svg that will hold chart
-    this.svg_chart = this.chart_container
+    this.svgChart = this.chartContainer
       .append("svg")
         .classed("chart", true)
-        .attr("viewBox", "0 0 " + (this.chart_width + this.margin.left + this.margin.right) + " " + (this.chart_height + this.margin.top + this.margin.bottom))
+        .attr("viewBox", "0 0 " + (this.chartWidth + this.margin.left + this.margin.right) + " " + (this.chartHeight + this.margin.top + this.margin.bottom))
         .attr("preserveAspectRatio", "xMidYMid meet")
       .append("g")
         .attr("transform","translate(" + this.margin.left + "," + this.margin.top + ")");
@@ -96,23 +96,23 @@ export default {
           // x axis scale
           const xScale = type()
             .domain([x_min, this.d3.max(data, x)])
-            .range([0, this.chart_width])
+            .range([0, this.chartWidth])
 
-          this.svg_chart.append("g")
-            .attr("transform", "translate(0," + this.chart_height + ")")
+          this.svgChart.append("g")
+            .attr("transform", "translate(0," + this.chartHeight + ")")
             .call(this.d3.axisBottom(xScale))
 
           // y axis scale for lolipop chart
           const yScale = this.d3.scaleBand()
-            .range([0, this.chart_height])
+            .range([0, this.chartHeight])
             .domain(data.map(function(d) { return d.feature }))
             .padding(1);
 
-          this.svg_chart.append("g")
+          this.svgChart.append("g")
             .call(this.d3.axisLeft(yScale))
 
           // add lolipop lines
-          this.svg_chart.selectAll("chartLines")
+          this.svgChart.selectAll("chartLines")
             .data(data)
             .enter()
             .append("line")
@@ -125,7 +125,7 @@ export default {
               // .on("mouseout", d => self.fadeEl(self.tooltip, 0, 50))
 
           // Add lolipop circles
-          this.svg_chart.selectAll("chartCircles")
+          this.svgChart.selectAll("chartCircles")
             .data(data)
             .enter()
             .append("circle")

--- a/src/components/pool_flux_chart.vue
+++ b/src/components/pool_flux_chart.vue
@@ -102,7 +102,7 @@ export default {
             .attr("transform", "translate(0," + this.chartHeight + ")")
             .call(this.d3.axisBottom(xScale))
 
-          // y axis scale for lolipop chart
+          // y axis scale for lollipop chart
           const yScale = this.d3.scaleBand()
             .range([0, this.chartHeight])
             .domain(data.map(function(d) { return d.feature }))
@@ -111,7 +111,7 @@ export default {
           this.svgChart.append("g")
             .call(this.d3.axisLeft(yScale))
 
-          // add lolipop lines
+          // add lollipop lines
           this.svgChart.selectAll("chartLines")
             .data(data)
             .enter()
@@ -124,7 +124,7 @@ export default {
               // .on("mouseover", d => self.populateTooltip(d))					
               // .on("mouseout", d => self.fadeEl(self.tooltip, 0, 50))
 
-          // Add lolipop circles
+          // Add lollipop circles
           this.svgChart.selectAll("chartCircles")
             .data(data)
             .enter()

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -1,9 +1,9 @@
 <template>
   <div id="visualization">
     <h2>Pools and Fluxes in the Water Cycle</h2>
-    <Logpile />
+    <PoolFluxChart />
     <p>
-      This visualization was inspired by the <a href="https://www.duncangeere.com/carbonincontext/" target="_blank">Carbon in Context</a> logpile chart by Duncan Geere. Data are adapted from <a href="https://www.nature.com/articles/s41561-019-0374-y" target="_blank">Abbott et al. (2019) Human domination of the global water cycle absent from depictions and perceptions.</a>  
+      Data are adapted from <a href="https://www.nature.com/articles/s41561-019-0374-y" target="_blank">Abbott et al. (2019) Human domination of the global water cycle absent from depictions and perceptions.</a>  
     </p>
   </div>
 </template>
@@ -13,7 +13,7 @@
 export default {
     name: 'Visualization',
     components: {
-      Logpile: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/logpile")
+      PoolFluxChart: () => import( /* webpackPreload: true */ /*webpackChunkName: "section"*/ "./../components/pool_flux_chart")
     },
     computed: {
     },

--- a/src/views/Visualization.vue
+++ b/src/views/Visualization.vue
@@ -3,7 +3,7 @@
     <h2>Pools and Fluxes in the Water Cycle</h2>
     <Logpile />
     <p>
-      This visualization was inspired by the <a href="https://www.duncangeere.com/carbonincontext/" target="_blank">Carbon in Context</a> logpile chart by Duncan Geere. The magnitude of water cycle components are from <a href="https://www.nature.com/articles/s41561-019-0374-y" target="_blank">Abbott et al. (2019) Human domination of the global water cycle absent from depictions and perceptions.</a>  
+      This visualization was inspired by the <a href="https://www.duncangeere.com/carbonincontext/" target="_blank">Carbon in Context</a> logpile chart by Duncan Geere. Data are adapted from <a href="https://www.nature.com/articles/s41561-019-0374-y" target="_blank">Abbott et al. (2019) Human domination of the global water cycle absent from depictions and perceptions.</a>  
     </p>
   </div>
 </template>


### PR DESCRIPTION
This PR sets up a basic lollipop chart of water cycle pools and fluxes. It re-uses much of the set-up from the former logpile component. I did a quick round of edits to use more generic variable names (e.g., `svgChart`) and to update the code to meet some of our JavaScript best practices, e.g., switch uses of `var` to `let` or `const`, use camelCase, though I likely did not catch everything.


Known issues:
* Chart does not scale as page is re-sized

Planned future edits to get to MVP:
* Add toggle to transition between log and linear scale for x axis
* Add interactivity - pop-up with name, volume/rate, definition, picture, and link to WSS page (if applicable)
* Refine styling and arrangement of elements on y axis
* Finalize styling and sizing of text

The page looks as follows:
![image](https://user-images.githubusercontent.com/54007288/189771467-2c606b12-4173-4fc8-98fc-c3964ed50a67.png)

With a manual switch to linear scale:
![image](https://user-images.githubusercontent.com/54007288/189772523-2f85001e-8677-49a1-8492-0bf1a963338d.png)

