### PR TITLE
Add back interaction

### DIFF
--- a/public/data/pools-fluxes-examples-limited.csv
+++ b/public/data/pools-fluxes-examples-limited.csv
@@ -1,38 +1,37 @@
-﻿type,feature,value_km_3
-Pool,Rivers,1900
-Pool,Snowpack,2900
-Pool,Atmospheric moisture - over land,3000
-Pool,Atmospheric moisture - over ocean,10000
-Pool,Reservoirs,10800
-Pool,Wetlands,14100
-Pool,Soil moisture,54100
-Pool,Lakes - saline,94700
-Pool,Lakes - fresh,108000
-Pool,Permafrost,207000
-Pool,Groundwater,22630000
-Pool,Ice sheets and glaciers,25800000
-Pool,Ocean - mixed zone,134000000
-Pool,Ocean - deep water zone,1206000000
-Flux,Streamflow to closed basins,800
-Flux,snowmelt,3100
-Flux,Groundwater discharge to ocean,4500
-Flux,Groundwater recharge,13000
-Flux,human water use,24400
-Flux,Streamflow to ocean,36000
-Flux,Transport of moisture from ocean to land,46000
-Flux,Evapotranspiration,68900
-Flux,Precipitation over land ,111000
-Flux,Precipitation over ocean,380500
-Flux,Ocean evaporation,420500
-Flux,Ocean circulation,7100000
-Example,Great Salt Lake,18.9
-Example,Dead Sea,147
-Example,Lake Winnepeg,284
-Example,Lake Erie,480
-Example,Lake Titicaca,893
-Example,Lake Victoria,2700
-Example,Grand canyon,4166.8
-Example,Lake Vostok,5400
-Example,Lake Superior,11600
-Example,Lake Baikal,23600
-Example,Caspian Sea,78200
+﻿type,feature,value_km_3,units,image_file,image_credit,definition
+Pool,Rivers,1900,cubic kilometers,river.jpg,Water Resources - Multimedia | U.S. Geological Survey (usgs.gov),A natural body of water that flows from higher to lower elevations as a result of gravity. Rivers typically flow into lakes or to the ocean but sometimes end due to evaporation or through loss of streamflow to groundwater. 
+Pool,Snowpack,2900,cubic kilometers,NA,NA,Snow that accumulates seasonally at high latitudes or elevations. 
+Pool,Atmospheric moisture - over land,3000,cubic kilometers,NA,NA,Water that is present as water vapor (water in gaseous form) in the atmosphere above land masses. Water vapor in the atmosphere is invisible to the human eye. 
+Pool,Atmospheric moisture - over ocean,10000,cubic kilometers,NA,NA,Water that is present as water vapor (water in gaseous form) in the atmosphere above oceans. Water vapor in the atmosphere is invisible to the human eye. 
+Pool,Reservoirs,10800,cubic kilometers,NA,NA,"A reservoir is a human-made lake. Reservoirs form when a dam is built on a river, allowing water to pool behind the dam."
+Pool,Wetlands,14100,cubic kilometers,wetlands.jpg,"Herring River Estuary, Cape Cod, MA | U.S. Geological Survey (usgs.gov)","Wetlands are areas where the soil is saturated or flooded year-round or during the growing season. Wetlands support the growth of aquatic (water) and terrestrial (land) plants that are adapted to grow in soils with low oxygen.  They include mangroves, marshes (salt, brackish, intermediate, and fresh), swamps, forested wetlands, bogs, wet prairies, prairie potholes, and vernal pools."
+Pool,Soil moisture,54100,cubic kilometers,soilMoisture.jpg,International Institute of Tropical Agriculture - https://www.flickr.com/photos/iita-media-library/7637264088,
+Pool,Lakes - saline,94700,cubic kilometers,salineLake.jpg,Bernadette Simpson - https://commons.wikimedia.org/wiki/File:Saline_Lake_at_Ras_Mohamed_National_Park.jpg,
+Pool,Lakes - fresh,108000,cubic kilometers,freshLake.jpg,Water Lake Nature - Free photo on Pixabay,
+Pool,Permafrost,207000,cubic kilometers,Permafrost.png,https://www.usgs.gov/media/images/mapping-barter-island-all-terrain-vehicle-atv,
+Pool,Groundwater,22630000,cubic kilometers,NA,NA,
+Pool,Ice sheets and glaciers,25800000,cubic kilometers,Glacier.jpg,File:Grinnell Glacier from summit of Mt Gould 2015 7648 crop.jpg - Wikimedia Commons,
+Pool,Ocean - mixed zone,134000000,cubic kilometers,NA,NA,
+Pool,Ocean - deep water zone,1206000000,cubic kilometers,NA,NA,
+Flux,Streamflow to closed basins,800,cubic kilometers per year,NA,NA,
+Flux,Groundwater discharge to ocean,4500,cubic kilometers per year,NA,NA,
+Flux,Groundwater recharge,13000,cubic kilometers per year,NA,NA,
+Flux,human water use,24400,cubic kilometers per year,NA,NA,
+Flux,Streamflow to ocean,36000,cubic kilometers per year,NA,NA,
+Flux,Transport of moisture from ocean to land,46000,cubic kilometers per year,NA,NA,
+Flux,Evapotranspiration,68900,cubic kilometers per year,NA,NA,
+Flux,Precipitation over land ,111000,cubic kilometers per year,landRain.jpg,100+ kostenlose Regen-Duschen und Regen-Bilder (pixabay.com),
+Flux,Precipitation over ocean,380500,cubic kilometers per year,oceanPrecipitation.jpg,Water Waves Horizon - Pixabay free pictures,
+Flux,Ocean evaporation,420500,cubic kilometers per year,NA,NA,
+Flux,Ocean circulation,7100000,cubic kilometers per year,NA,NA,
+Example pool,Great Salt Lake,18.9,cubic kilometers,NA,NA,
+Example pool,Dead Sea,147,cubic kilometers,deadSea.jpg,https://www.usgs.gov/media/images/kafrein-reservoir-captures-runoff-near-dead-sea-jordan,
+Example pool,Lake Winnepeg,284,cubic kilometers,NA,NA,
+Example pool,Lake Erie,480,cubic kilometers,lakeErie.jpg,Beautiful sunset landscape over lake erie free image download (pixy.org),
+Example pool,Lake Titicaca,893,cubic kilometers,lakeTiticaca.jpg,Do Lago Titicaca BolÃ­via Montanha - Foto gratuita no Pixabay,
+Example pool,Lake Victoria,2700,cubic kilometers,NA,NA,
+Example pool,Grand canyon,4166.8,cubic kilometers,grandCanyon.jpg,NA,
+Example pool,Lake Vostok,5400,cubic kilometers,NA,NA,
+Example pool,Lake Superior,11600,cubic kilometers,lakeSuperior.jpg,File:Gfp-michigan-upper-peninsula-shoreline-of-lake-superior.jpg - Wikimedia Commons,
+Example pool,Lake Baikal,23600,cubic kilometers,baikal.jpg,NA,
+Example pool,Caspian Sea,78200,cubic kilometers,NA,NA,

--- a/src/App.vue
+++ b/src/App.vue
@@ -102,7 +102,7 @@ h2{
   margin-top: 5px;
   line-height: 1.2;
   @media screen and (max-width: 600px) {
-    font-size: 2em;
+    font-size: 1.3em;
   }
 }
 h3{
@@ -118,5 +118,4 @@ p, text {
   padding: 1em 0 0 0; 
   font-family: $Assistant;
 }
-
 </style>

--- a/src/components/dialog.vue
+++ b/src/components/dialog.vue
@@ -1,0 +1,133 @@
+<template>
+  <div v-show="show" class="overlay">
+
+
+    <div class="dialog">
+
+      <div class="dialog__content">
+        <h2 class="dialog__title" v-text="title"></h2>
+        <h3 class="dialog__type" v-text="type"></h3>
+        <p class="dialog__size" v-text="size"></p>
+        <img v-bind:src="source" width="200px" height="200px">
+        <p class="dialog__definition" v-text="definition"></p>
+      </div>
+    
+      <hr />
+
+      <div class="dialog__footer">
+        <button @click="close" class="dialog__close">Close</button>
+      </div>
+
+    </div>
+
+  </div>
+</template>
+
+<script>
+export default {
+    props: ['show', 'title', 'type', 'size', 'source', 'definition', 'close']
+}
+</script>
+<style>
+
+.overlay {
+  --tw-bg-opacity: 1;
+  background-color: rgba(0, 0, 0, var(--tw-bg-opacity));
+  --tw-bg-opacity: 0.5;
+  height: 100%;
+  position: fixed;
+  top: 0px;
+  right: 0px;
+  bottom: 0px;
+  left: 0px;
+  width: 100%;
+  z-index: 10;
+}
+.dialog {
+  --tw-bg-opacity: 1;
+  background-color: rgba(255, 255, 255, var(--tw-bg-opacity));
+  border-radius: 0.75rem;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 2.5rem;
+  max-width: 100%;
+  width: 24rem;
+}
+.dialog__content {
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.dialog__title {
+  font-weight: 500;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+  margin-bottom: 0.5rem;
+  --tw-text-opacity: 1;
+  color: rgba(17, 24, 39, var(--tw-text-opacity));
+}
+.dialog__type {
+  font-weight: 500;
+  font-size: 1 rem;
+  line-height: 1.75rem;
+  margin-bottom: 0.5rem;
+  --tw-text-opacity: 1;
+  color: rgba(17, 24, 39, var(--tw-text-opacity));
+}
+.dialog__size {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  margin-bottom: 1rem;
+  --tw-text-opacity: 1;
+  color: rgba(107, 114, 128, var(--tw-text-opacity));
+}
+.dialog__definition {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  margin-bottom: 1rem;
+  --tw-text-opacity: 1;
+  color: rgba(107, 114, 128, var(--tw-text-opacity));
+}
+.dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+}
+.dialog__close {
+  border-radius: 0.75rem;
+  font-weight: 500;
+  margin-right: 1rem;
+}
+.dialog__close:focus{
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+}
+.dialog__close{
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+.dialog__close:focus{
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgba(75, 85, 99, var(--tw-ring-opacity));
+  --tw-ring-opacity: 0.5;
+}
+.dialog__close{
+  --tw-text-opacity: 1;
+  color: rgba(17, 24, 39, var(--tw-text-opacity));
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
+}
+.dialog__close:hover {
+  --tw-text-opacity: 1;
+  color: rgba(55, 65, 81, var(--tw-text-opacity));
+}
+</style>

--- a/src/components/pool_flux_chart.vue
+++ b/src/components/pool_flux_chart.vue
@@ -179,7 +179,7 @@ export default {
             .attr("height", this.chartHeight/data.length) //yScale.bandwidth() should work but returns 0
             .style("fill", "white")
             .style("opacity",0)
-            .on("click", d => self.populateTooltip(d))
+            .on("click", d => self.populateCard(d))
 
         },
         imagePath(file){
@@ -187,7 +187,7 @@ export default {
           return image_src
 
         },
-        populateTooltip(d){
+        populateCard(d){
           const self = this;
 
           // Populate card with information


### PR DESCRIPTION
This PR adds back in the chart interaction, with the goal of providing the name of the feature, its type (pool/flux/example), its volume/rate, an image and a definition. We may later also add in a link to WSS page, if available.

##### Initial plan:
Have a tooltip div that would be in a fixed location and would be populated and updated as you moused over the chart elements. 

As I started to implement this I realized it would be pretty tedious to get it to fit on the page in a good position at all page sizes, and with varying amounts of content (e.g. definitions of different lengths, image or no image).

##### Adapted implementation:

I realized what might be best was using a card that would pop up and then could be closed. I found a [youTube tutorial for creating dialogs in Vue](https://www.youtube.com/watch?v=hmvxqXUS-BU), and figured if I could get a button set up so that it launched a dialog box within 20 minutes then I'd go ahead and see if I could get it to work for the interaction. The tutorial was great and it ended up being pretty straightforward to set up a dialog Vue component and then set up a function to customize the dialog card. I think this will be really easy to adapt and use for other projects.

The interaction is triggered when you click on fully transparent rectangles that span the full width of the chart (including y-axis labels).

It looks like this:
![PoolsFluxesCard](https://user-images.githubusercontent.com/54007288/190293799-4845e754-bd91-45c8-8ab5-ebb5cf5904f3.gif)

##### Not yet addressed
* There needs to be some indication (visual or a text prompt) that the user can click on the chart elements to pull up additional information
* Not all of the features have definitions currently - I only pasted in the first few
* Not all of the features have images
* The card needs to be styled