### PR TITLE
Revert axis label

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,13 +35,13 @@
       <meta property="og:url" content="labs.waterdata.usgs.gov/visualizations/pools-and-fluxes">
       <meta property="og:title" content="Pools and fluxes in the water cycle">
       <meta property="og:description" content="The magnitude of water on Earth">
-      <meta property="og:image" content="labs.waterdata.usgs.gov/visualizations/thumbnails/pnf.png">
+      <meta property="og:image" content="labs.waterdata.usgs.gov/visualizations/thumbnails/pnf-thumbnail.png">
       <!-- Twitter -->
       <meta property="twitter:card" content="summary_large_image">
       <meta property="twitter:url" content="labs.waterdata.usgs.gov/visualizations/pools-and-fluxes">
       <meta property="twitter:title" content="Pools and fluxes in the water cycle">
       <meta property="twitter:description" content="The magnitude of water on Earth">
-      <meta property="twitter:image" content="labs.waterdata.usgs.gov/visualizations/thumbnails/pnf.png">
+      <meta property="twitter:image" content="labs.waterdata.usgs.gov/visualizations/thumbnails/pnf-thumbnail.png">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
 <script type='application/ld+json'>
       { "@context": "http://www.schema.org",

--- a/src/components/pool_flux_chart.vue
+++ b/src/components/pool_flux_chart.vue
@@ -278,20 +278,12 @@ export default {
             .attr("class", "x_axis")
 
           // Add x-axis label on mobile and desktop
-          let XAxisLabelForeignObject = this.svgChart.append("foreignObject")
-              .attr("id", "x-label-container")
-              .attr("x", 0)
-              .attr("y", -this.margin.top)
-              .attr("width", this.chartWidth)
-
-          let XAxisLabelDiv = XAxisLabelForeignObject
-            .append("xhtml:div")
-              .append("div")
-          
-          let xAxisLabel = XAxisLabelDiv
-            .append("p")
-              .attr("class", 'x_label top')
-              .html("<span class='pool pageText emph'>Pool</span> volume (km³) or <span class='flux pageText emph'>flux</span> rate (km³ per year)")
+          this.svgChart.append("text")
+               .attr("class", "x_label")
+               .attr("text-anchor", "middle")
+               .attr("x", this.chartWidth/2)
+               .attr("y", -32)
+               .text("Pool volume (km³) or flux rate (km³ per year)")
 
           // y axis scale for lollipop chart
           const yScale = this.d3.scaleBand()


### PR DESCRIPTION
Revert to standard axis label on mobile and desktop (b/c of Safari display issue)

Update link for meta card